### PR TITLE
Pry::MethodInfo.gem_root: return gem root instead of ruby root

### DIFF
--- a/lib/pry-doc.rb
+++ b/lib/pry-doc.rb
@@ -137,7 +137,9 @@ class Pry
     # FIXME: this is unnecessarily limited to ext/ and lib/ folders
     # @return [String] The root folder of a given gem directory.
     def self.gem_root(dir)
-      dir.split(/\/(?:lib|ext)(?:\/|$)/).first
+      if index = dir.rindex(/\/(?:lib|ext)(?:\/|$)/)
+        dir[0..index-1]
+      end
     end
 
     # @param [Method, UnboundMethod] meth The method object.

--- a/spec/pry-doc_spec.rb
+++ b/spec/pry-doc_spec.rb
@@ -158,7 +158,25 @@ describe PryDoc do
 
       lambda { Pry::MethodInfo.aliases(c.method(:my_method)) }.should.not.raise NameError
     end
+  end
 
+  describe ".gem_root" do
+    it "should return the path to the gem" do
+      path = Pry::WrappedModule.new(Sample).source_location[0]
+
+      Pry::MethodInfo.gem_root(path).should ==
+        File.expand_path("gem_with_cext/gems", direc)
+    end
+
+    it "should not be fooled by a parent 'lib' or 'ext' dir" do
+      path = "/foo/.rbenv/versions/1.9.3-p429/lib/ruby/gems/"\
+             "1.9.1/gems/activesupport-4.0.2/lib/active_support/"\
+             "core_ext/kernel/reporting.rb"
+
+      Pry::MethodInfo.gem_root(path).should ==
+        "/foo/.rbenv/versions/1.9.3-p429/lib/ruby/"\
+        "gems/1.9.1/gems/activesupport-4.0.2"
+    end
   end
 
   if Pry::Helpers::BaseHelpers.mri_18?


### PR DESCRIPTION
This seems to fix #16.

Still not ideal, though:
- Scanning `active_support` for methods on Kernel seems bad.
- If we don't find anything, we'll try again and again the next time. Luckily, `Pry::MethodInfo.c_files_found?(path/to/active_support)` is fast here. And returns false.
- This still doesn't work with the [Debian packaging structure](https://packages.debian.org/jessie/all/ruby-activesupport-3.2/filelist) (I just looked it up). But whatever, they brought it on themselves. (And `gem_root` won't be called in those cases anyway).
