### PR TITLE
Don't load wrong yardocs, warn user about unsupported Ruby version

### DIFF
--- a/lib/pry-doc.rb
+++ b/lib/pry-doc.rb
@@ -22,8 +22,10 @@ when /\A2\.1/
   PryDoc.load_yardoc('21')
 when /\A2\.0/
   PryDoc.load_yardoc('20')
-else
+when /\A1.9/
   PryDoc.load_yardoc('19')
+else
+  puts "Ruby #{RUBY_VERSION} isn't supported by this pry-doc version"
 end
 
 class Pry


### PR DESCRIPTION
I use pry & pry-doc gems with ruby 2.3 without any problem. But I lost couple of hours because I didn't realize that pry-doc lies to me when I use $ Foo#bar for methods implemented in C. After investigation I found to my surprise that it shows me source from ruby 1.9! Here is simple patch that at least prevent pry-doc gem from loading wrong yardocs for unsupported rubies.