### PR TITLE
Add `sample.bundle` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pkg/
 *.gem
 Gemfile.lock
 *~
+sample.bundle


### PR DESCRIPTION
When we run test, `sample.bundle` is generated.
But we need not to controll this file.