### PR TITLE
Allow use of ruby-head (Ruby 2.5.0-dev)

### DIFF
--- a/lib/pry-doc.rb
+++ b/lib/pry-doc.rb
@@ -7,7 +7,7 @@ module PryDoc
   def self.load_yardoc(version)
     path = "#{File.dirname(__FILE__)}/pry-doc/docs/#{version}"
     unless File.directory?(path)
-      raise "#{RUBY_ENGINE}/#{RUBY_VERSION} isn't supported by this pry-doc version"
+      puts "#{RUBY_ENGINE}/#{RUBY_VERSION} isn't supported by this pry-doc version"
     end
 
     # Do not use pry-doc if Rubinius is active.


### PR DESCRIPTION
Thanks for the release of pry-doc 0.10.0.


So here goes the main topic.
I offen using ruby-head (currently Ruby 2.5.0-dev) with Rails.

The following change raises an exception `Gem Load Error is: ruby/2.5.0 isn't supported by this pry-doc version` when using ruby-head.

https://github.com/pry/pry-doc/commit/f2eb5f6f9382d81af6268d9dbe2bb95fd51397f2#diff-a80fb2c425dee3addc62d4caf9a81bb2L16

Environments:

- ruby 2.5.0dev (2017-01-02 trunk 57252) [x86_64-darwin13]
- rails (5.0.1)
- pry-doc (0.10.0)

Backtrace is below.

```sh
% bundle exec rails c
/Users/koic/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/activesupport-5.0.1/lib/active_support/xml_mini.rb:51: warning: constant ::Fixnum is deprecated
/Users/koic/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/activesupport-5.0.1/lib/active_support/xml_mini.rb:52: warning: constant ::Bignum is deprecated
/Users/koic/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.13.7/lib/bundler/runtime.rb:94:in `rescue in block (2 levels) in require': There was an error while trying to load the gem 'pry-doc'. (Bundler::GemRequireError)
Gem Load Error is: ruby/2.5.0 isn't supported by this pry-doc version
Backtrace for gem load error is:
/Users/koic/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pry-doc-0.10.0/lib/pry-doc.rb:10:in `load_yardoc'
/Users/koic/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pry-doc-0.10.0/lib/pry-doc.rb:20:in `<top (required)>'
```
</details>

Therefore, I cannot start Rails (`rails c`, `rails s` and so on) .

I'd like to use ruby-head what I can.

This PR will make changes behavior from exception to logging. That is the previous behavior.

How do you think about this change?

Thanks.
