### PR TITLE
Fixed deprecation warning for pry v0.12.0

### DIFF
--- a/lib/pry-doc/pry_ext/show_source_with_c_internals/c_file.rb
+++ b/lib/pry-doc/pry_ext/show_source_with_c_internals/c_file.rb
@@ -53,7 +53,7 @@ module Pry::CInternals
       end
 
       def windows?
-        if Gem::Version.create(Pry::VERSION) < Gem::Version.create("0.12.0")
+        if Gem::Version.new(Pry::VERSION) < Gem::Version.new("0.12.0")
           Pry::Platform.windows?
         else
           Pry::Helpers::Platform.windows?

--- a/lib/pry-doc/pry_ext/show_source_with_c_internals/c_file.rb
+++ b/lib/pry-doc/pry_ext/show_source_with_c_internals/c_file.rb
@@ -44,11 +44,19 @@ module Pry::CInternals
       end
 
       def full_path_for(file_name)
-        if Pry::Platform.windows?
+        if windows?
           # windows etags already has the path expanded, wtf
           file_name
         else
           File.join(ruby_source_folder, @file_name)
+        end
+      end
+
+      def windows?
+        if Gem::Version.create(Pry::VERSION) < Gem::Version.create("0.12.0")
+          Pry::Platform.windows?
+        else
+          Pry::Helpers::Platform.windows?
         end
       end
 

--- a/lib/pry-doc/pry_ext/show_source_with_c_internals/ruby_source_installer.rb
+++ b/lib/pry-doc/pry_ext/show_source_with_c_internals/ruby_source_installer.rb
@@ -25,15 +25,31 @@ module Pry::CInternals
     private
 
     def set_platform_specific_commands
-      if Pry::Platform.windows?
+      if windows?
         self.curl_cmd = "curl -k --fail -L -O https://github.com/ruby/ruby/archive/v#{ruby_version}.zip " +
                         "& 7z -y x v#{ruby_version}.zip"
         self.etag_binary = File.join(PryDoc.root, "libexec/windows/etags")
         self.etag_cmd = %{dir /b /s *.c *.h *.y | "#{etag_binary}" - --no-members}
       else
         self.curl_cmd = "curl --fail -L https://github.com/ruby/ruby/archive/v#{ruby_version}.tar.gz | tar xzvf - 2> /dev/null"
-        self.etag_binary = Pry::Platform.linux? ? File.join(PryDoc.root, "libexec/linux/etags-#{arch}") : "etags"
+        self.etag_binary = linux? ? File.join(PryDoc.root, "libexec/linux/etags-#{arch}") : "etags"
         self.etag_cmd = "find . -type f -name '*.[chy]' | #{etag_binary} - --no-members"
+      end
+    end
+
+    def windows?
+      if Gem::Version.create(Pry::VERSION) < Gem::Version.create("0.12.0")
+        Pry::Platform.windows?
+      else
+        Pry::Helpers::Platform.windows?
+      end
+    end
+
+    def linux?
+      if Gem::Version.create(Pry::VERSION) < Gem::Version.create("0.12.0")
+        Pry::Platform.linux?
+      else
+        Pry::Helpers::Platform.linux?
       end
     end
 

--- a/lib/pry-doc/pry_ext/show_source_with_c_internals/ruby_source_installer.rb
+++ b/lib/pry-doc/pry_ext/show_source_with_c_internals/ruby_source_installer.rb
@@ -38,7 +38,7 @@ module Pry::CInternals
     end
 
     def windows?
-      if Gem::Version.create(Pry::VERSION) < Gem::Version.create("0.12.0")
+      if Gem::Version.new(Pry::VERSION) < Gem::Version.new("0.12.0")
         Pry::Platform.windows?
       else
         Pry::Helpers::Platform.windows?
@@ -46,7 +46,7 @@ module Pry::CInternals
     end
 
     def linux?
-      if Gem::Version.create(Pry::VERSION) < Gem::Version.create("0.12.0")
+      if Gem::Version.new(Pry::VERSION) < Gem::Version.new("0.12.0")
         Pry::Platform.linux?
       else
         Pry::Helpers::Platform.linux?


### PR DESCRIPTION
c.f. https://github.com/pry/pry/blob/master/CHANGELOG.md#v0120-november-5-2018

# Now (pry v0.12.0 + pry-doc v0.13.4)

```
$ bundle exec rspec
/Users/sue445/workspace/github.com/pry/pry-doc/lib/pry-doc/pry_ext/show_source_with_c_internals/ruby_source_installer.rb:28: warning: constant Pry::Platform is deprecated
/Users/sue445/workspace/github.com/pry/pry-doc/lib/pry-doc/pry_ext/show_source_with_c_internals/ruby_source_installer.rb:35: warning: constant Pry::Platform is deprecated

Building Sample Gem with C Extensions for testing..
creating Makefile
compiling sample.c
linking shared-object sample.bundle

Testing pry-doc version 0.13.4...
Ruby version: 2.5.1

Randomized with seed 14933
Scanning and caching *.c files...
......../Users/sue445/workspace/github.com/pry/pry-doc/lib/pry-doc/pry_ext/show_source_with_c_internals/c_file.rb:47: warning: constant Pry::Platform is deprecated
./Users/sue445/workspace/github.com/pry/pry-doc/lib/pry-doc/pry_ext/show_source_with_c_internals/c_file.rb:47: warning: constant Pry::Platform is deprecated
...../Users/sue445/workspace/github.com/pry/pry-doc/lib/pry-doc/pry_ext/show_source_with_c_internals/c_file.rb:47: warning: constant Pry::Platform is deprecated
.../Users/sue445/workspace/github.com/pry/pry-doc/lib/pry-doc/pry_ext/show_source_with_c_internals/c_file.rb:47: warning: constant Pry::Platform is deprecated
...../Users/sue445/workspace/github.com/pry/pry-doc/lib/pry-doc/pry_ext/show_source_with_c_internals/c_file.rb:47: warning: constant Pry::Platform is deprecated
..................

Finished in 0.56493 seconds (files took 3.31 seconds to load)
40 examples, 0 failures

Randomized with seed 14933
```

# After (pry v0.12.0 + pry-doc my branch)
```
$ bundle exec rspec

Building Sample Gem with C Extensions for testing..
creating Makefile
linking shared-object sample.bundle

Testing pry-doc version 0.13.4...
Ruby version: 2.5.1

Randomized with seed 14605
Scanning and caching *.c files...
........................................

Finished in 0.19723 seconds (files took 0.73212 seconds to load)
40 examples, 0 failures

Randomized with seed 14605
```

# After (pry v0.11.3 + pry-doc my branch)
```
$ bundle exec rspec

Building Sample Gem with C Extensions for testing..
creating Makefile
linking shared-object sample.bundle

Testing pry-doc version 0.13.4...
Ruby version: 2.5.1

Randomized with seed 3241
Scanning and caching *.c files...
........................................

Finished in 0.1765 seconds (files took 0.56779 seconds to load)
40 examples, 0 failures

Randomized with seed 3241
```