### PR TITLE
Fixed. doesn't work with MRI 2.0

### DIFF
--- a/lib/pry-doc/pry_ext/show_source_with_c_internals/c_file.rb
+++ b/lib/pry-doc/pry_ext/show_source_with_c_internals/c_file.rb
@@ -17,7 +17,7 @@ module Pry::CInternals
       attr_accessor :file_name
       attr_reader :ruby_source_folder
 
-      def initialize(file_name:, content:, ruby_source_folder: nil)
+      def initialize(file_name: nil, content: nil, ruby_source_folder: nil)
         @ruby_source_folder = ruby_source_folder
         @content = content
         @file_name = file_name


### PR DESCRIPTION
This is regression of https://github.com/pry/pry-doc/commit/6b9f920

It seems `pry-doc` supports MRI 2.0.
https://github.com/pry/pry-doc/blob/v0.13.4/pry-doc.gemspec#L23

But required keyword argument is available since MRI 2.1+