### PR TITLE
Fix a build error for Ruby 2.2 or lower matrix on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 before_install:
-  - gem update --system
   - gem update bundler
 
 rvm:


### PR DESCRIPTION
RubyGems 3.0.1 requires Ruby 2.3.0 or higher.
https://github.com/rubygems/rubygems/blob/v3.0.1/rubygems-update.gemspec#L32

This PR fixes the following build error.

```console
$ gem update --system
Updating rubygems-update
Fetching: rubygems-update-3.0.1.gem (100%)
ERROR:  Error installing rubygems-update:
        rubygems-update requires Ruby version >= 2.3.0.
ERROR:  While executing gem ... (NoMethodError)
    undefined method `version' for nil:NilClass
The command "gem update --system" failed and exited with 1 during .
```

https://travis-ci.org/pry/pry-doc/jobs/472067448#L485-L492