### PR TITLE
Update README installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,8 @@ Install the gem using the below command.
 
     gem install pry-doc
 
-To use `pry-doc`, you will need to manually require the gem inside `pry`.
-
-    require 'pry-doc'
-
-If you want `pry` to automatically load `pry-doc` upon starting `pry`, you will need to add the command `require 'pry-doc'` to your `prysrc`.
-You can read more about it [here][pry-overview].
+To automatically load `pry-doc` upon starting `pry`, add the command `require 'pry-doc'` to your `pryrc`.
+You can read more about it in Pry's [README file][pry-overview].
 
 Synopsis
 --------

--- a/README.md
+++ b/README.md
@@ -14,10 +14,16 @@ for Pry.
 Installation
 ------------
 
-All you need is to install the gem. The `pry-doc` plugin will be detected and
-used automatically.
+Install the gem using the below command.
 
     gem install pry-doc
+
+To use `pry-doc`, you will need to manually require the gem inside `pry`.
+
+    require 'pry-doc'
+
+If you want `pry` to automatically load `pry-doc` upon starting `pry`, you will need to add the command `require pry-doc` to your `prysrc`.
+You can read more about it [here][pry-overview].
 
 Synopsis
 --------
@@ -55,6 +61,7 @@ The project uses the MIT License. See LICENSE file for more information.
 
 [logo]: http://img-fotki.yandex.ru/get/6724/98991937.13/0_9faaa_26ec83af_orig "Pry Doc"
 [pry]: https://github.com/pry/pry
+[pry-overview]: https://github.com/pry/pry#overview
 [show-source]: http://img-fotki.yandex.ru/get/9303/98991937.13/0_9faac_aa86e189_orig "show-source extended by Pry Doc"
 [show-doc]: http://img-fotki.yandex.ru/get/9058/98991937.13/0_9faab_68d7a43a_orig "show-doc extended by Pry Doc"
 [repo]: https://github.com/pry/pry-doc

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To use `pry-doc`, you will need to manually require the gem inside `pry`.
 
     require 'pry-doc'
 
-If you want `pry` to automatically load `pry-doc` upon starting `pry`, you will need to add the command `require pry-doc` to your `prysrc`.
+If you want `pry` to automatically load `pry-doc` upon starting `pry`, you will need to add the command `require 'pry-doc'` to your `prysrc`.
 You can read more about it [here][pry-overview].
 
 Synopsis


### PR DESCRIPTION
Pry deprecated automatic loading of plug-ins some time ago. I spent hours trying to figure out why pry-doc was not loading automatically, until I realized that automatic loading is not supported anymore. 
I provided an explanation of how to auto load pry-doc, with link to pry's github where they explain in detail how it works.