### PR TITLE
Fix failing spec on Ruby 3.0

### DIFF
--- a/spec/pry-doc_spec.rb
+++ b/spec/pry-doc_spec.rb
@@ -239,14 +239,14 @@ EOF
 
     it 'should look up core (C) class method (by Method object)' do
       obj = Module.module_eval do
-        Pry::MethodInfo.info_for(Dir.method(:glob))
+        Pry::MethodInfo.info_for(Dir.method(:mkdir))
       end
       expect(obj.source).not_to be_nil
     end
 
     it 'should look up core (C) class method (by UnboundMethod object)' do
       obj = Module.module_eval do
-        Pry::MethodInfo.info_for(class << Dir; instance_method(:glob); end)
+        Pry::MethodInfo.info_for(class << Dir; instance_method(:mkdir); end)
       end
       expect(obj.source).not_to be_nil
     end


### PR DESCRIPTION
Hi there 🙌 

I think those specs are failing because Dir.glob is not being found over the [C docs yard was generated from](https://github.com/pry/pry-doc/blob/master/Rakefile#L80-L85).

Investigating why I saw that Dir.glob was moved into `dir.rb` and removed from `dir.c` on the following commit https://github.com/ruby/ruby/commit/60e25e37d4db86249d3c25e03d96875eb98d9e43#diff-7b6c9d59e98b433bac23d954cfeb47fb25e36e93cdad448ffa777612fb52cc52

Changing this spec to a method still defined in C would make those specs pass and that could unblock the release?

Ideally for other `$ Dir.glob` and other methods moved for .rb files to work like it was on 2.7 there is a little bit more work. For example, adding those dir.rb and other files do the yardoc generation. I can investigate a bit more. Would that make sense?
