### PR TITLE
Specify rexml < 3.2.5 for ruby versions <= 2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 gemspec
 
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+  gem 'rexml', '< 3.2.5'
+end


### PR DESCRIPTION
Hello again @kyrylo 🙌 

As the latest rexml version is broken on Ruby < 2.3 seems like the easier way is to specify a lower version on the Gemfile. That is, in case ruby 2.0 is still to be supported here.

From https://github.com/ruby/rexml/blob/master/README.md
```
The required_ruby_version on the gemspec is kept updated on a best-effort basis by the community. Up to version 3.2.5, this information was not set. That version is known broken with at least Ruby < 2.3.
```

rexml ends up as dependency here because of the latest_ruby gem. It's only used locally to generate docs as far as I can see. I was able to test this locally and it works.

So, CI must install a rexml < 3.2.5 in order to keep things working on 2.0.  