### PR TITLE
Fix Ruby 3.4 build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'bigdecimal'


### PR DESCRIPTION
The build was failing because bigdecimal is no longer part of the default gems for Ruby 3.4. I'm adding it to the Gemfile to fix this. 

We could look into another gem later.